### PR TITLE
TASK: Tweak nodetypes configuration

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -8,8 +8,6 @@
     icon: icon-trash
   constraints:
     nodeTypes:
-      'Ttree.ArchitectesCh:Activity': false
-      'Ttree.ArchitectesCh:ReferenceActivity': true
       '*': false
   properties:
     targetMode:

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -10,6 +10,8 @@
     nodeTypes:
       '*': false
   properties:
+    _hidden:
+      defaultValue: true
     targetMode:
       type: string
       defaultValue: parentNode


### PR DESCRIPTION
Removes custom nodetypes from the constraints and hides the Trash node by default.